### PR TITLE
Added flag to log request/response in plain text if required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ export SYSLOG_PROTOCOL=tcp
 export APICAST_MODULE=custom/verbose
 ```
 
+Plain text logging of payload without base64 encoding:
+```
+export APICAST_PAYLOAD_BASE64=false 
+```
+
 Then, you need to register a resolver in the nginx configuration (example using the Google DNS):
 ```
 cat <<EOF > apicast/apicast.d/resolver.conf


### PR DESCRIPTION
Added a environment variable flag APICAST_PAYLOAD_BASE64 to switch base64 encoding ON or OFF. By default the request/response will be base64 encoded while logging. The flag can take two values 'true' or 'false'. Default value is set to 'true'.